### PR TITLE
Improvements & Update to Swift 5

### DIFF
--- a/Instantiable.swift
+++ b/Instantiable.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-protocol Instantiable: class {
+protocol Instantiable: AnyObject {
     static func instantiate() -> Self
 }
 

--- a/VIPER.xctemplate/Module/___FILEBASENAME___Interactor.swift
+++ b/VIPER.xctemplate/Module/___FILEBASENAME___Interactor.swift
@@ -10,8 +10,8 @@
 
 import Foundation
 
-class ___VARIABLE_productName:identifier___Interactor: ___VARIABLE_productName:identifier___InteractorInputProtocol
-{
+class ___VARIABLE_productName:identifier___Interactor: ___VARIABLE_productName:identifier___InteractorInputProtocol {
+    
     weak var presenter: ___VARIABLE_productName:identifier___InteractorOutputProtocol?
     
 }

--- a/VIPER.xctemplate/Module/___FILEBASENAME___Presenter.swift
+++ b/VIPER.xctemplate/Module/___FILEBASENAME___Presenter.swift
@@ -10,8 +10,8 @@
 
 import UIKit
 
-class ___VARIABLE_productName:identifier___Presenter: ___VARIABLE_productName:identifier___PresenterProtocol
-{
+class ___VARIABLE_productName:identifier___Presenter: ___VARIABLE_productName:identifier___PresenterProtocol {
+    
     weak var view: ___VARIABLE_productName:identifier___ViewControllerProtocol?
     var interactor: ___VARIABLE_productName:identifier___InteractorInputProtocol?
     var wireFrame: ___VARIABLE_productName:identifier___WireframeProtocol?
@@ -19,7 +19,6 @@ class ___VARIABLE_productName:identifier___Presenter: ___VARIABLE_productName:id
 }
 
 // MARK: - Interactor Output
-extension ___VARIABLE_productName:identifier___Presenter: ___VARIABLE_productName:identifier___InteractorOutputProtocol
-{
+extension ___VARIABLE_productName:identifier___Presenter: ___VARIABLE_productName:identifier___InteractorOutputProtocol {
     
 }

--- a/VIPER.xctemplate/Module/___FILEBASENAME___Protocols.swift
+++ b/VIPER.xctemplate/Module/___FILEBASENAME___Protocols.swift
@@ -11,31 +11,26 @@
 import UIKit
 
 // PRESENTER -> VIEW
-protocol ___VARIABLE_productName:identifier___ViewControllerProtocol: UIViewController
-{
+protocol ___VARIABLE_productName:identifier___ViewControllerProtocol: UIViewController {
     
 }
 
 // PRESENTER -> INTERACTOR
-protocol ___VARIABLE_productName:identifier___InteractorInputProtocol: AnyObject
-{
+protocol ___VARIABLE_productName:identifier___InteractorInputProtocol: AnyObject {
     
 }
 
 // INTERACTOR -> PRESENTER
-protocol ___VARIABLE_productName:identifier___InteractorOutputProtocol: AnyObject
-{
+protocol ___VARIABLE_productName:identifier___InteractorOutputProtocol: AnyObject {
     
 }
 
 // VIEW -> PRESENTER
-protocol ___VARIABLE_productName:identifier___PresenterProtocol: AnyObject
-{
+protocol ___VARIABLE_productName:identifier___PresenterProtocol: AnyObject {
     
 }
 
 // PRESENTER -> ROUTER
-protocol ___VARIABLE_productName:identifier___WireframeProtocol: AnyObject
-{
+protocol ___VARIABLE_productName:identifier___WireframeProtocol: AnyObject {
     
 }

--- a/VIPER.xctemplate/Module/___FILEBASENAME___Protocols.swift
+++ b/VIPER.xctemplate/Module/___FILEBASENAME___Protocols.swift
@@ -10,42 +10,31 @@
 
 import UIKit
 
-// VIEW
+// PRESENTER -> VIEW
 protocol ___VARIABLE_productName:identifier___ViewControllerProtocol: UIViewController
 {
-    var presenter: ___VARIABLE_productName:identifier___PresenterProtocol? { get set }
-    
-    // PRESENTER -> VIEW
     
 }
 
-// INTERACTOR
+// PRESENTER -> INTERACTOR
 protocol ___VARIABLE_productName:identifier___InteractorInputProtocol: AnyObject
 {
-    var presenter: ___VARIABLE_productName:identifier___InteractorOutputProtocol? { get set }
-    
-    // PRESENTER -> INTERACTOR
     
 }
 
+// INTERACTOR -> PRESENTER
 protocol ___VARIABLE_productName:identifier___InteractorOutputProtocol: AnyObject
 {
-    // INTERACTOR -> PRESENTER
     
 }
 
-// PRESENTER
+// VIEW -> PRESENTER
 protocol ___VARIABLE_productName:identifier___PresenterProtocol: AnyObject
 {
-    var view: ___VARIABLE_productName:identifier___ViewControllerProtocol? { get set }
-    var interactor: ___VARIABLE_productName:identifier___InteractorInputProtocol? { get set }
-    var wireFrame: ___VARIABLE_productName:identifier___WireframeProtocol? { get set }
-    
-    // VIEW -> PRESENTER
     
 }
 
-// ROUTER
+// PRESENTER -> ROUTER
 protocol ___VARIABLE_productName:identifier___WireframeProtocol: AnyObject
 {
     

--- a/VIPER.xctemplate/Module/___FILEBASENAME___Protocols.swift
+++ b/VIPER.xctemplate/Module/___FILEBASENAME___Protocols.swift
@@ -20,7 +20,7 @@ protocol ___VARIABLE_productName:identifier___ViewControllerProtocol: UIViewCont
 }
 
 // INTERACTOR
-protocol ___VARIABLE_productName:identifier___InteractorInputProtocol: class
+protocol ___VARIABLE_productName:identifier___InteractorInputProtocol: AnyObject
 {
     var presenter: ___VARIABLE_productName:identifier___InteractorOutputProtocol? { get set }
     
@@ -28,14 +28,14 @@ protocol ___VARIABLE_productName:identifier___InteractorInputProtocol: class
     
 }
 
-protocol ___VARIABLE_productName:identifier___InteractorOutputProtocol: class
+protocol ___VARIABLE_productName:identifier___InteractorOutputProtocol: AnyObject
 {
     // INTERACTOR -> PRESENTER
     
 }
 
 // PRESENTER
-protocol ___VARIABLE_productName:identifier___PresenterProtocol: class
+protocol ___VARIABLE_productName:identifier___PresenterProtocol: AnyObject
 {
     var view: ___VARIABLE_productName:identifier___ViewControllerProtocol? { get set }
     var interactor: ___VARIABLE_productName:identifier___InteractorInputProtocol? { get set }
@@ -46,7 +46,7 @@ protocol ___VARIABLE_productName:identifier___PresenterProtocol: class
 }
 
 // ROUTER
-protocol ___VARIABLE_productName:identifier___WireframeProtocol: class
+protocol ___VARIABLE_productName:identifier___WireframeProtocol: AnyObject
 {
     
 }

--- a/VIPER.xctemplate/Module/___FILEBASENAME___ViewController.swift
+++ b/VIPER.xctemplate/Module/___FILEBASENAME___ViewController.swift
@@ -10,19 +10,12 @@
 
 import UIKit
 
-class ___VARIABLE_productName:identifier___ViewController: UIViewController, Instantiable
-{
-    var presenter: ___VARIABLE_productName:identifier___PresenterProtocol?
+class ___VARIABLE_productName:identifier___ViewController: UIViewController, Instantiable {
     
-    override func viewDidLoad()
-    {
-        super.viewDidLoad()
-        
-    }
+    var presenter: ___VARIABLE_productName:identifier___PresenterProtocol?
 }
 
 // MARK: - Presenter Output
-extension ___VARIABLE_productName:identifier___ViewController: ___VARIABLE_productName:identifier___ViewControllerProtocol
-{
+extension ___VARIABLE_productName:identifier___ViewController: ___VARIABLE_productName:identifier___ViewControllerProtocol {
     
 }

--- a/VIPER.xctemplate/Module/___FILEBASENAME___Wireframe.swift
+++ b/VIPER.xctemplate/Module/___FILEBASENAME___Wireframe.swift
@@ -15,9 +15,9 @@ class ___VARIABLE_productName:identifier___Wireframe: ___VARIABLE_productName:id
     static func assemblyModule() -> UIViewController
     {
         let viewController = ___VARIABLE_productName:identifier___ViewController.instantiate()
-        let presenter: ___VARIABLE_productName:identifier___PresenterProtocol & ___VARIABLE_productName:identifier___InteractorOutputProtocol = ___VARIABLE_productName:identifier___Presenter()
-        let interactor: ___VARIABLE_productName:identifier___InteractorInputProtocol = ___VARIABLE_productName:identifier___Interactor()
-        let wireFrame: ___VARIABLE_productName:identifier___WireframeProtocol = ___VARIABLE_productName:identifier___Wireframe()
+        let presenter = ___VARIABLE_productName:identifier___Presenter()
+        let interactor = ___VARIABLE_productName:identifier___Interactor()
+        let wireFrame: = ___VARIABLE_productName:identifier___Wireframe()
         
         viewController.presenter = presenter
         presenter.view = viewController

--- a/VIPER.xctemplate/Module/___FILEBASENAME___Wireframe.swift
+++ b/VIPER.xctemplate/Module/___FILEBASENAME___Wireframe.swift
@@ -10,10 +10,9 @@
 
 import UIKit
 
-class ___VARIABLE_productName:identifier___Wireframe: ___VARIABLE_productName:identifier___WireframeProtocol
-{
-    static func assemblyModule() -> UIViewController
-    {
+class ___VARIABLE_productName:identifier___Wireframe: ___VARIABLE_productName:identifier___WireframeProtocol {
+    
+    static func assemblyModule() -> UIViewController {
         let viewController = ___VARIABLE_productName:identifier___ViewController.instantiate()
         let presenter = ___VARIABLE_productName:identifier___Presenter()
         let interactor = ___VARIABLE_productName:identifier___Interactor()


### PR DESCRIPTION
Remove layer's dependencies from protocols. Each layer should know only about it's own dependencies. (ViewController should not be able to access presenter's interactor, for example).